### PR TITLE
feat: multi-platform binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,48 +32,94 @@ jobs:
         run: cargo test --workspace
 
   build:
-    name: Build Linux Binary
+    name: Build ${{ matrix.target }}
     needs: test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-latest
+            cross: true
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            cross: false
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            cross: false
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
+        if: ${{ !matrix.cross }}
+        with:
+          targets: ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release --bin cordelia-node
+      - name: Install cross
+        if: ${{ matrix.cross }}
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
-      - name: Strip binary
-        run: strip target/release/cordelia-node
+      - name: Build release binary (native)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --bin cordelia-node --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: ${{ matrix.cross }}
+        run: cross build --release --bin cordelia-node --target ${{ matrix.target }}
+
+      - name: Strip binary (Linux)
+        if: contains(matrix.target, 'linux') && !matrix.cross
+        run: strip target/${{ matrix.target }}/release/cordelia-node
+
+      - name: Strip binary (Linux cross)
+        if: contains(matrix.target, 'linux') && matrix.cross
+        run: |
+          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/cordelia-node
+
+      - name: Strip binary (macOS)
+        if: contains(matrix.target, 'apple')
+        run: strip target/${{ matrix.target }}/release/cordelia-node
 
       - name: Rename binary
-        run: cp target/release/cordelia-node cordelia-node-x86_64-linux
+        run: cp target/${{ matrix.target }}/release/cordelia-node cordelia-node-${{ matrix.target }}
 
-      - name: Generate checksum
-        run: sha256sum cordelia-node-x86_64-linux > sha256sums.txt
+      - name: Generate checksum (Linux)
+        if: contains(matrix.target, 'linux')
+        run: sha256sum cordelia-node-${{ matrix.target }} > cordelia-node-${{ matrix.target }}.sha256
+
+      - name: Generate checksum (macOS)
+        if: contains(matrix.target, 'apple')
+        run: shasum -a 256 cordelia-node-${{ matrix.target }} > cordelia-node-${{ matrix.target }}.sha256
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-binaries
+          name: cordelia-node-${{ matrix.target }}
           path: |
-            cordelia-node-x86_64-linux
-            sha256sums.txt
+            cordelia-node-${{ matrix.target }}
+            cordelia-node-${{ matrix.target }}.sha256
 
   release:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifacts
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-binaries
+          merge-multiple: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            cordelia-node-x86_64-linux
-            sha256sums.txt
+            cordelia-node-*
           generate_release_notes: true

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,36 @@
+# Cordelia Node Configuration
+# Copy to ~/.cordelia/config.toml and replace __ENTITY_ID__ with your user ID.
+# Generated values (identity key, database) are created by install.sh.
+
+[identity]
+user_id = "__ENTITY_ID__"
+
+[paths]
+memory_root = "~/.cordelia/memory"
+
+[node]
+identity_key = "~/.cordelia/node.key"
+api_transport = "http"
+api_addr = "127.0.0.1:9473"
+database = "~/.cordelia/cordelia.db"
+entity_id = "__ENTITY_ID__"
+
+[network]
+listen_addr = "0.0.0.0:9474"
+
+[[network.bootnodes]]
+addr = "boot1.cordelia.seeddrill.ai:9474"
+
+[[network.bootnodes]]
+addr = "boot2.cordelia.seeddrill.ai:9474"
+
+[governor]
+hot_min = 2
+hot_max = 20
+warm_min = 10
+warm_max = 50
+
+[replication]
+sync_interval_moderate_secs = 300
+tombstone_retention_days = 7
+max_batch_size = 100


### PR DESCRIPTION
## Summary

- Expand `release.yml` from single x86_64-linux build to 4-target matrix: x86_64-linux, aarch64-linux (via `cross`), x86_64-apple-darwin (macos-13), aarch64-apple-darwin (macos-14)
- Each target produces `cordelia-node-{target}` (stripped) + `cordelia-node-{target}.sha256`
- Add `config.toml.example` template with `__ENTITY_ID__` placeholder and `.ai` bootnodes

## Notes for Martin

- `macos-13` for Intel, `macos-14` for Apple Silicon
- Linux aarch64 uses `cross` -- swap for self-hosted ARM runner if preferred
- Binary URL pattern: `https://github.com/seed-drill/cordelia-core/releases/latest/download/cordelia-node-{target}`
- Adjust runners/caching as needed

## Test plan

- [ ] Tag a release and verify all 4 binaries + checksums appear in GitHub release
- [ ] Download each binary, verify SHA256 matches
- [ ] `cordelia-node-aarch64-apple-darwin` runs on M1+

🤖 Generated with [Claude Code](https://claude.com/claude-code)